### PR TITLE
Fix font sizes for all chrome elements

### DIFF
--- a/styles/components/_breadcrumbs.scss
+++ b/styles/components/_breadcrumbs.scss
@@ -11,6 +11,7 @@ Breadcrumbs - Co-op Front-end Toolkit
   color: $coop-grey;
   margin-top: -$half-spacing-unit;
   margin-bottom: $half-spacing-unit;
+  font-size: em-calc(14);
 
   @include media(medium) {
     background: $offwhite;
@@ -21,7 +22,6 @@ Breadcrumbs - Co-op Front-end Toolkit
   li {
     display: inline;
     list-style: none;
-    font-size: em-calc(14);
 
     &:after {
       @extend %icon;

--- a/styles/components/_footer-main.scss
+++ b/styles/components/_footer-main.scss
@@ -29,12 +29,15 @@ Main footer - Co-op Front-end Toolkit
     border-top: 1px solid $coop-border-grey;
 
     h4 {
+      margin-bottom: $quarter-spacing-unit;
       color: $coop-blue;
+      font-size: em-calc(16);
     }
 
     ul {
       @include list-bare;
       margin-bottom: $half-spacing-unit;
+      font-size: em-calc(16);
 
       li {
         margin-bottom: $quarter-spacing-unit;
@@ -67,6 +70,7 @@ Main footer - Co-op Front-end Toolkit
     ul {
       @include list-inline;
       margin-bottom: 0;
+      font-size: em-calc(16);
     }
 
     a {
@@ -92,6 +96,7 @@ Main footer - Co-op Front-end Toolkit
     padding-top: $quarter-spacing-unit;
     padding-bottom: $quarter-spacing-unit;
     text-align: center;
+    color: $coop-grey;
 
     p {
       margin: 0;

--- a/styles/components/_navigation-main.scss
+++ b/styles/components/_navigation-main.scss
@@ -30,6 +30,7 @@ Main navigation - Co-op Front-end Toolkit
   ul {
     @include list-bare;
     margin: 0 0 $quarter-spacing-unit;
+    font-size: em-calc(16);
 
     @include media(medium) {
       margin: 0;


### PR DESCRIPTION
Some chrome elements (main nav, footer nav, etc) currently rescale when new font sizes are applied to standard typographic elements (`<p>`, `<ul>`, etc). Instead, these should remain the same size, allowing us to apply different font sizes to common elements globally and not affect the main layout.
