### PR TITLE
Fixed path to functions in icon mixin file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules/
 bower_components/
 npm-debug.log
+.idea/

--- a/styles/mixins/_icons.scss
+++ b/styles/mixins/_icons.scss
@@ -2,7 +2,7 @@
 Icons mixins - Co-op Front-end Toolkit
 ===============================================*/
 
-@import "functions";
+@import "../functions";
 
 @font-face {
   font-family: 'coopicons';


### PR DESCRIPTION
It uses @import functions instead of @import ../functions, which causes it to throw the following error: 

Error: bower_components/coop-frontend-toolkit/styles/mixins/_icons.scss
Error: File to import not found or unreadable: functions
       Parent style sheet: /Users/ckok/Projects/coop/member-portal/bower_components/coop-frontend-toolkit/styles/mixins/_icons.scss
        on line 5 of bower_components/coop-frontend-toolkit/styles/mixins/_icons.scss
