### PR TITLE
Fix logo hover

### DIFF
--- a/styles/components/_skip-nav.scss
+++ b/styles/components/_skip-nav.scss
@@ -12,6 +12,7 @@ Skip navigation link - Co-op Front-end Toolkit
 
   ul {
     list-style: none;
+    margin: 0;
   }
 
   a {


### PR DESCRIPTION
Logo could not be hovered on small screens due to the bottom margin
still present on the Skip Nav ul being over the top left part of the
logo. Margin is now zeroed, so the mouse can target the logo properly.
