### PR TITLE
Include modules init call in main toolkit js

### DIFF
--- a/scripts/coop-toolkit.js
+++ b/scripts/coop-toolkit.js
@@ -21,3 +21,8 @@
   // expose the Coop object globally
   window.Coop = Coop;
 })();
+
+$(function() {
+  // Initialise all modules
+  Coop.init();
+});


### PR DESCRIPTION
This removes the need for manually calling Coop.init() from your application -- including the Toolkit JS loader is now sufficient.

cc @richhiggins 
