### PR TITLE
Remove copy colour setting for tables

### DIFF
--- a/styles/_tables.scss
+++ b/styles/_tables.scss
@@ -11,10 +11,6 @@ table {
     text-align: left;
   }
 
-  tbody, tfoot {
-    color: $coop-grey;
-  }
-
   thead {
     background-color: $coop-blue;
     color: $white;


### PR DESCRIPTION
Tables now use the default body copy colour.

Fixes https://github.com/coopdigital/single-site-styleguide/issues/16
