### PR TITLE
Add 'nowrap' text helper

### DIFF
--- a/styles/_helpers.scss
+++ b/styles/_helpers.scss
@@ -83,6 +83,10 @@ Helpers - Co-op Front-end Toolkit
   text-align: right;
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
 .visuallyhidden {
   @include visuallyhidden;
 }


### PR DESCRIPTION
used mostly to prevent instances of 'Co-op' from being split onto two
lines, eg. `<span class="nowrap">Co-op</span>`
