### PR TITLE
update global body font-size to remove em-calc function from declaration

### DIFF
--- a/styles/_global.scss
+++ b/styles/_global.scss
@@ -14,7 +14,7 @@ Global - Co-op Front-end Toolkit
 
 html,
 body {
-  font-size: em-calc(map-deep-get($typographic-scale, "base", "body"));
+  font-size: map-deep-get($typographic-scale, "base", "body");
 }
 
 body {


### PR DESCRIPTION
Remove em-calc from global.scss body font-size.  Causing issues in overriding typographic scale due to em being set as base font-size.

Tested manually via browserstack:
Windows 7 - IE8/IE9, Firefox
Windows 8 - IE10, Firefox latest, Chrome, Safari 5.1 
Windows 10 - Edge/IE11, Safari5.1 and Firefox latest

Mac OS Sierra - Safari latest, Chrome latest, Firefox latest
Android: Nexus 6 - Chrome, Firefox