### PR TITLE
Propose a new README style guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Co-op Front-end Toolkit contains all the core assets needed to build Co-op-branded digital content.
 
-For more information on all the available styles and modules, please refer to the [Co-op Style Guide](http://single-site-styleguide.herokuapp.com/front-end-elements/).
+For more information on all the available styles and modules, please refer to the [Co-op Style Guide](https://coop-design-manual.herokuapp.com/).
 
 ## Installation
 


### PR DESCRIPTION
I followed the link to the styleguide in the readme and hit a site with basic auth.

It wasn't clear to me where I could get those auth details which is probably just an internal documentation detail...

But if I were an external user interested in co-op design guide that's not the greatest flow so am proposing that we link to the design manual instead.

Or should we have both links and direct external users to the design manual?