### PR TITLE
Remove the link to the old style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Co-op Front-end Toolkit contains all the core assets needed to build Co-op-branded digital content.
 
-For more information on all the available styles and modules, please refer to the [Co-op Style Guide](http://single-site-styleguide.herokuapp.com/front-end-elements/).
+For more information on all the available styles and modules, please refer to the [Co-op Design Manual](http://coop.co.uk/designmanual).
 
 ## Installation
 


### PR DESCRIPTION
... Instead, link it to the design manual.

Suggest that we also take down the hosted http://single-site-styleguide.herokuapp.com/front-end-elements/

/cc @matt-tyas 