### PR TITLE
Typography defaults

### DIFF
--- a/styles/_tables.scss
+++ b/styles/_tables.scss
@@ -10,7 +10,7 @@ Tables - Co-op Front-end Toolkit
 table {
   width: 100%;
   table-layout: fixed;
-  font-size: 20px;
+  @include body;
   @include spacing('margin', 'bottom', 'half');
 
   caption {
@@ -91,7 +91,6 @@ table {
     tbody {
       th {
         display: block;
-        font-size: 16px;
         border-top: 2px solid $coop-border-grey;
         margin-top: $quarter-spacing-unit;
       }
@@ -103,14 +102,12 @@ table {
       td {
         display: block;
         border-bottom: 0;
-        font-size: 16px;
 
         &:before {
           content: attr(data-th)"";
           vertical-align: top;
           font-family: $regular;
           font-weight: normal;
-          font-size: 16px;
           // Should be amended with a custom value...
           width: 40%;
           display: inline-block;
@@ -122,7 +119,6 @@ table {
 
       ul {
         display: inline-block;
-        font-size: 16px;
         // This old chestnut https://css-tricks.com/fighting-the-space-between-inline-block-elements/
         margin-left: -5px;
       }
@@ -176,10 +172,6 @@ table {
 
   .table__bold {
      font-family: $bold;
-     font-size: em-calc(20);
-     @include media(medium) {
-       font-size: em-calc(26);
-     }
   }
 }
 

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -22,14 +22,12 @@ address {
 p {
   @include body;
   @include spacing('margin', 'bottom', 'quarter');
-  font-family: $regular;
 }
 
 ul,
 ol {
-  font-size: 20px;
+  @include body;
   @include spacing('margin', 'bottom', 'quarter');
-  font-family: $regular;
 }
 
 p:last-child {

--- a/styles/mixins/_typography.scss
+++ b/styles/mixins/_typography.scss
@@ -7,7 +7,6 @@ Typography amd Vertical Rhythm mixins - Co-op Front-end Toolkit
 
 @mixin font-size($element: 'body', $line-height: $base-line-height) {
   font-size: em-calc(map-deep-get($typographic-scale, "base", $element));
-  font-family: $bold;
 
   @if $line-height != $base-line-height {
     line-height: $line-height;
@@ -143,40 +142,47 @@ $spacing-rhythm: 'base', 'half', 'quarter', 'eighth', 'sixteenth';
 
 // Headings
 @mixin heading-mega {
+  @include bold;
   @include font-size('h-mega', 1.385);
   @include spacing('margin', 'bottom', 'half');
   @include spacing('padding', 'top', 'half');
 }
 
 @mixin heading-h1 {
+  @include bold;
   @include font-size('h1', 1.4);
   @include spacing('margin', 'bottom', 'half');
 }
 
 @mixin heading-h2 {
+  @include bold;
   @include font-size('h2', 1.55);
   @include spacing('margin', 'bottom', 'eighth');
 }
 
 @mixin heading-h3 {
+  @include bold;
   @include font-size('h3', 1.455);
   @include spacing('padding', 'top', 'eighth');
   @include spacing('margin', 'bottom', 'eighth');
 }
 
 @mixin heading-h4 {
+  @include bold;
   @include font-size('h4', 1.455);
   @include spacing('padding', 'top', 'eighth');
   @include spacing('margin', 'bottom', 'eighth');
 }
 
 @mixin heading-h5 {
+  @include bold;
   @include font-size('h5', 1.455);
   @include spacing('padding', 'top', 'eighth');
   @include spacing('margin', 'bottom', 'eighth');
 }
 
 @mixin heading-h6 {
+  @include bold;
   @include font-size('h6', 1.5);
   @include spacing('padding', 'top', 'quarter');
   @include spacing('margin', 'bottom', 'sixteenth');
@@ -185,14 +191,12 @@ $spacing-rhythm: 'base', 'half', 'quarter', 'eighth', 'sixteenth';
 @mixin intro-text {
   @include font-size('lead', 1.6);
   @include spacing('margin', 'bottom', 'eighth');
-  font-family: $regular;
 }
 
 @mixin small {
   @include font-size('small', 1.25);
   @include spacing('padding', 'top', 'quarter');
   @include spacing('margin', 'bottom', 'sixteenth');
-  font-family: $regular;
 }
 
 // Other typographic elements
@@ -230,7 +234,6 @@ $spacing-rhythm: 'base', 'half', 'quarter', 'eighth', 'sixteenth';
   cite {
     @include body;
     @include spacing('margin', 'top', 'quarter');
-    font-family: $regular;
     font-style: normal;
   }
 
@@ -238,7 +241,6 @@ $spacing-rhythm: 'base', 'half', 'quarter', 'eighth', 'sixteenth';
 
 @mixin cite {
   display: block;
-  font-family: $regular;
   font-size: 0.75em;
 }
 


### PR DESCRIPTION
- Use Regular typeface as default for body, and override for headings
- Remove hard-coded pixel font-sizes from tables and provide defaults that follow body font size more closely.